### PR TITLE
Better handling for no public repos

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -17,8 +17,29 @@ export const github: CommandInt = {
       `https://api.github.com/users/${cmdArguments}/repos?sort=updated`
     );
     const ghRepoParsed: GithubRepoInt[] = await ghRepoData.json();
-    if (ghUser.message === "Not Found" || !ghRepoParsed[0]) {
+    if (ghUser.message === "Not Found") {
       message.channel.send("ERROR 404: Data not found.");
+      return;
+    }
+    if (!ghRepoParsed[0]) {
+      const ghEmbed = new MessageEmbed()
+        .setTitle(`Github User: ${ghUser.login}`)
+        .setDescription(ghUser.bio || "No description provided")
+        .setURL(ghUser.html_url)
+        .addFields(
+          { name: "Name", value: ghUser.name },
+          {
+            name: "Followers",
+            value: ghUser.followers,
+          },
+          { name: "Join Date", value: ghUser.created_at },
+          {
+            name: "Repository Counts",
+            value: `${ghUser.public_repos} public repositories`,
+          }
+        );
+      if (ghUser.avatar_url) ghEmbed.setImage(ghUser.avatar_url);
+      message.channel.send(ghEmbed);
       return;
     }
     const ghRepo = ghRepoParsed.slice(0, 5);


### PR DESCRIPTION
# Pull Request

## Description:
This PR adjusts the handling for the github command when there are no public repositories for the queried user. Rather than returning nothing, the command now returns an embed sans repository links.
## Requirements:

<!-- Ensure you have completed the steps in this checklist, and put an x in each of the boxes: [x]. Failure to do so will delay the review of your pull request.-->

- [X] I have read the repository readme.
- [X] My pull request has a descriptive title.
- [X] My pull request targets the `master` branch of the repository.
- [X] My pull request contains code that is my own work, or is properly attributed.

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
