### PR TITLE
Fix #176 - Leaving guild changes mention

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -73,7 +73,7 @@ client.on("guildMemberAdd", (member) => {
     .setColor("#ab47e6")
     .setTitle("A new user has joined! 🙃")
     .setDescription(
-      `Hello everyone! Let us give a warm welcome to <@!${member.user}>!`
+      `Hello everyone! Let us give a warm welcome to \`${member.user?.username}\`!`
     );
   const welcomeChannel = member.guild.channels.cache.find(
     (channel) => channel.name === config.join_leave_channel


### PR DESCRIPTION
# Pull Request

## Description:

Instead of mentioning a user when they are added to the guild, it uses inline code markdown to display their username.

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #176 
