### PR TITLE
Bug/interceptable listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "homepage": "https://github.com/nhcarrigan/discord-bot#readme",
   "scripts": {
     "build": "rm -rf ./prod && tsc",
-    "coverage": "nyc",
+    "precoverage": "rm -rf ./coverage ./nyc_output",
+    "coverage": "nyc npm run test:unit",
     "dev": "nodemon",
     "dev:command": "npm run build && npm run start:ts",
     "lint": "eslint src --fix",

--- a/src/events/onMessage.ts
+++ b/src/events/onMessage.ts
@@ -81,7 +81,7 @@ async function onMessage(
         3000
       );
 
-      return Promise.resolve();
+      return;
     }
   }
   // Get the current Discord server id.

--- a/src/events/onMessage.ts
+++ b/src/events/onMessage.ts
@@ -45,13 +45,10 @@ async function onMessage(
   if (!guild) {
     return;
   }
-
   // Get the heartsListener, levelsListener and usageListener from the listeners list.
-  const {
-    heartsListener,
-    interceptedLevelsListener: levelsListener,
-    interceptedUsageListener: usageListener,
-  } = client.customListeners;
+  const { heartsListener } = client.customListeners;
+  const levelsListener = client.customListeners.interceptableLevelsListener;
+  const usageListener = client.customListeners.interceptableUsageListener;
 
   // Check if the heartsListener and levelsListener exists.
   if (heartsListener && levelsListener) {
@@ -61,7 +58,6 @@ async function onMessage(
     // Execute the levels listener.
     await levelsListener.run(message);
   }
-
   // Check if the file has attachments (Files, images or videos).
   if (attachments.array().length) {
     let haveAFile = false;
@@ -85,10 +81,9 @@ async function onMessage(
         3000
       );
 
-      return;
+      return Promise.resolve();
     }
   }
-
   // Get the current Discord server id.
   const server_id = guild.id;
 
@@ -111,12 +106,10 @@ async function onMessage(
 
     prefix = client.prefix[server_id];
   }
-
   // Check if the content of the message starts with the server prefix.
   if (!content.startsWith(prefix)) {
     return;
   }
-
   // Get the first argument as the command name.
   message.commandName = message.commandArguments.shift() || prefix;
 
@@ -129,7 +122,6 @@ async function onMessage(
   // Check if the command exists.
   if (command) {
     channel.startTyping();
-
     // Check if the usage listener exists.
     if (usageListener) {
       // Execute the usage listener.

--- a/test/unit/events/onMessage.spec.ts
+++ b/test/unit/events/onMessage.spec.ts
@@ -1,16 +1,16 @@
 import { SinonSandbox, createSandbox, SinonStub, clock } from "sinon";
-import { mock } from "ts-mockito";
+import { mock, reset } from "ts-mockito";
 import CommandInt from "@Interfaces/CommandInt";
 import ListenerInt from "@Interfaces/ListenerInt";
 import onMessage from "@Events/onMessage";
 import extendsClientToClientInt from "@Utils/extendsClientToClientInt";
 import { getListeners } from "@Utils/readDirectory";
-import * as IUL from "@Listeners/interceptableUsageListener";
 import { expect } from "chai";
 import * as discordjs from "discord.js";
 
 describe("onMessage event", () => {
   const testPrefix = "☂";
+  const MAGIC_TIMEOUT = 3000;
   let sandbox: SinonSandbox;
   const mockCmd = (name = "mockCmd", run: SinonStub): CommandInt => ({
     names: [name, `mock ${name}`],
@@ -31,6 +31,7 @@ describe("onMessage event", () => {
   });
 
   afterEach(() => {
+    reset();
     sandbox.restore();
   });
 
@@ -56,7 +57,7 @@ describe("onMessage event", () => {
       });
 
       const msgPromise = onMessage(msg, clientInt);
-      await sandbox.clock.tickAsync(3000);
+      await sandbox.clock.tickAsync(MAGIC_TIMEOUT);
       await msgPromise;
 
       const inUselistener =
@@ -88,12 +89,109 @@ describe("onMessage event", () => {
       });
 
       const msgPromise = onMessage(msg, clientInt);
-      await sandbox.clock.tickAsync(3000);
+      await sandbox.clock.tickAsync(MAGIC_TIMEOUT);
       await msgPromise;
 
       const inUselistener = clientInt.customListeners["heartsListener"];
 
       expect(inUselistener.run).calledOnce;
+    });
+  });
+
+  context("is direct message", () => {
+    it("should send warning", async () => {
+      const aboutStub = sandbox.stub().resolves();
+      const client = mock<discordjs.Client>();
+      const msg = mock<discordjs.Message>();
+      const author = mock<discordjs.User>();
+      author.id = "1";
+      msg.author = author;
+      msg.content = `${testPrefix}about`;
+      msg.attachments = new discordjs.Collection();
+      msg.channel.startTyping = sandbox.stub();
+      msg.channel.stopTyping = sandbox.stub();
+      msg.channel.send = sandbox.stub().resolves();
+      msg.channel.type = "dm";
+      msg.guild.id = "server_id";
+
+      const clientInt = extendsClientToClientInt(client);
+      clientInt.prefix = { server_id: testPrefix };
+      clientInt.user = mock<discordjs.User>();
+      clientInt.user.id = "2";
+      clientInt.commands = { about: mockCmd("about", aboutStub) };
+      clientInt.customListeners = await getListeners();
+      Object.keys(clientInt.customListeners).forEach((key) => {
+        const stub = sandbox.stub();
+        stub.resolves();
+        clientInt.customListeners[key] = mockListener(key, stub);
+      });
+
+      const msgPromise = onMessage(msg, clientInt);
+      await sandbox.clock.tickAsync(MAGIC_TIMEOUT);
+      await msgPromise;
+
+      expect(msg.channel.startTyping).calledOnce;
+      expect(msg.channel.stopTyping).calledOnce;
+      expect(msg.channel.send).calledOnce;
+      expect(aboutStub).not.called;
+    });
+  });
+  context("is not a discord server", () => {
+    it("should return without calling command", async () => {
+      const aboutStub = sandbox.stub().resolves();
+      const client = mock<discordjs.Client>();
+      const msg = mock<discordjs.Message>();
+      const author = mock<discordjs.User>();
+      author.id = "1";
+      msg.author = author;
+      msg.content = `${testPrefix}about`;
+      msg.attachments = new discordjs.Collection();
+
+      const clientInt = extendsClientToClientInt(client);
+      clientInt.prefix = { server_id: testPrefix };
+      clientInt.user = mock<discordjs.User>();
+      clientInt.commands = { about: mockCmd("about", aboutStub) };
+      clientInt.customListeners = await getListeners();
+      Object.keys(clientInt.customListeners).forEach((key) => {
+        const stub = sandbox.stub();
+        stub.resolves();
+        clientInt.customListeners[key] = mockListener(key, stub);
+      });
+
+      await onMessage(msg, clientInt);
+
+      expect(aboutStub).not.called;
+    });
+  });
+
+  context("command does not start with prefix", () => {
+    it("should return without calling command", async () => {
+      const aboutStub = sandbox.stub().resolves();
+      const client = mock<discordjs.Client>();
+      const msg = mock<discordjs.Message>();
+      const author = mock<discordjs.User>();
+      author.id = "1";
+      msg.author = author;
+      msg.content = `>about`;
+      msg.attachments = new discordjs.Collection();
+      msg.channel.startTyping = sandbox.stub();
+      msg.channel.stopTyping = sandbox.stub();
+      msg.channel.send = sandbox.stub().resolves();
+      msg.guild.id = "server_id";
+
+      const clientInt = extendsClientToClientInt(client);
+      clientInt.prefix = { server_id: testPrefix };
+      clientInt.commands = { about: mockCmd("about", aboutStub) };
+      clientInt.customListeners = await getListeners();
+      Object.keys(clientInt.customListeners).forEach((key) => {
+        const stub = sandbox.stub();
+        stub.resolves();
+        clientInt.customListeners[key] = mockListener(key, stub);
+      });
+
+      await onMessage(msg, clientInt);
+
+      expect(aboutStub).not.called;
     });
   });
 
@@ -120,7 +218,7 @@ describe("onMessage event", () => {
         });
 
         const msgPromise = onMessage(msg, clientInt);
-        await sandbox.clock.tickAsync(3000);
+        await sandbox.clock.tickAsync(MAGIC_TIMEOUT);
         await msgPromise;
 
         const inUselistener =
@@ -152,7 +250,7 @@ describe("onMessage event", () => {
       });
 
       const msgPromise = onMessage(msg, clientInt);
-      await sandbox.clock.tickAsync(3000);
+      await sandbox.clock.tickAsync(MAGIC_TIMEOUT);
 
       await msgPromise;
 

--- a/test/unit/events/onMessage.spec.ts
+++ b/test/unit/events/onMessage.spec.ts
@@ -140,23 +140,18 @@ describe("onMessage event", () => {
     it("should return without calling command", async () => {
       const aboutStub = sandbox.stub().resolves();
       const client = mock<discordjs.Client>();
-      const msg = mock<discordjs.Message>();
+      const msg: discordjs.Message & { guild } = mock<discordjs.Message>();
       const author = mock<discordjs.User>();
       author.id = "1";
       msg.author = author;
       msg.content = `${testPrefix}about`;
       msg.attachments = new discordjs.Collection();
+      msg.guild = null;
 
       const clientInt = extendsClientToClientInt(client);
       clientInt.prefix = { server_id: testPrefix };
       clientInt.user = mock<discordjs.User>();
       clientInt.commands = { about: mockCmd("about", aboutStub) };
-      clientInt.customListeners = await getListeners();
-      Object.keys(clientInt.customListeners).forEach((key) => {
-        const stub = sandbox.stub();
-        stub.resolves();
-        clientInt.customListeners[key] = mockListener(key, stub);
-      });
 
       await onMessage(msg, clientInt);
 

--- a/test/unit/events/onMessage.spec.ts
+++ b/test/unit/events/onMessage.spec.ts
@@ -1,0 +1,162 @@
+import { SinonSandbox, createSandbox, SinonStub, clock } from "sinon";
+import { mock } from "ts-mockito";
+import CommandInt from "@Interfaces/CommandInt";
+import ListenerInt from "@Interfaces/ListenerInt";
+import onMessage from "@Events/onMessage";
+import extendsClientToClientInt from "@Utils/extendsClientToClientInt";
+import { getListeners } from "@Utils/readDirectory";
+import * as IUL from "@Listeners/interceptableUsageListener";
+import { expect } from "chai";
+import * as discordjs from "discord.js";
+
+describe("onMessage event", () => {
+  const testPrefix = "☂";
+  let sandbox: SinonSandbox;
+  const mockCmd = (name = "mockCmd", run: SinonStub): CommandInt => ({
+    names: [name, `mock ${name}`],
+    description: "mock",
+    run,
+  });
+  const mockListener = (
+    name = "mockListener",
+    run: SinonStub
+  ): ListenerInt => ({
+    name,
+    description: "mock",
+    run,
+  });
+  beforeEach(() => {
+    sandbox = createSandbox();
+    sandbox.useFakeTimers();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  context("heart & level listeners exist", () => {
+    it("should call run on interceptableLevelsListener", async () => {
+      const aboutStub = sandbox.stub().resolves();
+      const client = mock<discordjs.Client>();
+      const msg = mock<discordjs.Message>();
+      msg.content = `${testPrefix}about`;
+      msg.attachments = new discordjs.Collection();
+      msg.channel.startTyping = sandbox.stub();
+      msg.channel.stopTyping = sandbox.stub();
+      msg.guild.id = "server_id";
+
+      const clientInt = extendsClientToClientInt(client);
+      clientInt.prefix = { server_id: testPrefix };
+      clientInt.commands = { about: mockCmd("about", aboutStub) };
+      clientInt.customListeners = await getListeners();
+      Object.keys(clientInt.customListeners).forEach((key) => {
+        const stub = sandbox.stub();
+        stub.resolves();
+        clientInt.customListeners[key] = mockListener(key, stub);
+      });
+
+      const msgPromise = onMessage(msg, clientInt);
+      await sandbox.clock.tickAsync(3000);
+      await msgPromise;
+
+      const inUselistener =
+        clientInt.customListeners["interceptableLevelsListener"];
+      const notUselistener = clientInt.customListeners["levelsListener"];
+
+      expect(inUselistener.run).calledOnce;
+      expect(notUselistener.run).not.called;
+    });
+
+    it("should call run on heartsListener", async () => {
+      const aboutStub = sandbox.stub().resolves();
+      const client = mock<discordjs.Client>();
+      const msg = mock<discordjs.Message>();
+      msg.content = `${testPrefix}about`;
+      msg.attachments = new discordjs.Collection();
+      msg.channel.startTyping = sandbox.stub();
+      msg.channel.stopTyping = sandbox.stub();
+      msg.guild.id = "server_id";
+
+      const clientInt = extendsClientToClientInt(client);
+      clientInt.prefix = { server_id: testPrefix };
+      clientInt.commands = { about: mockCmd("about", aboutStub) };
+      clientInt.customListeners = await getListeners();
+      Object.keys(clientInt.customListeners).forEach((key) => {
+        const stub = sandbox.stub();
+        stub.resolves();
+        clientInt.customListeners[key] = mockListener(key, stub);
+      });
+
+      const msgPromise = onMessage(msg, clientInt);
+      await sandbox.clock.tickAsync(3000);
+      await msgPromise;
+
+      const inUselistener = clientInt.customListeners["heartsListener"];
+
+      expect(inUselistener.run).calledOnce;
+    });
+  });
+
+  context("command exists", () => {
+    context("usageListener exists", () => {
+      it("should call run on interceptableUsageListener", async () => {
+        const aboutStub = sandbox.stub().resolves();
+        const client = mock<discordjs.Client>();
+        const msg = mock<discordjs.Message>();
+        msg.content = `${testPrefix}about`;
+        msg.attachments = new discordjs.Collection();
+        msg.channel.startTyping = sandbox.stub();
+        msg.channel.stopTyping = sandbox.stub();
+        msg.guild.id = "server_id";
+
+        const clientInt = extendsClientToClientInt(client);
+        clientInt.prefix = { server_id: testPrefix };
+        clientInt.commands = { about: mockCmd("about", aboutStub) };
+        clientInt.customListeners = await getListeners();
+        Object.keys(clientInt.customListeners).forEach((key) => {
+          const stub = sandbox.stub();
+          stub.resolves();
+          clientInt.customListeners[key] = mockListener(key, stub);
+        });
+
+        const msgPromise = onMessage(msg, clientInt);
+        await sandbox.clock.tickAsync(3000);
+        await msgPromise;
+
+        const inUselistener =
+          clientInt.customListeners["interceptableUsageListener"];
+        const notUselistener = clientInt.customListeners["usageListener"];
+
+        expect(inUselistener.run).calledOnce;
+        expect(notUselistener.run).not.called;
+      });
+    });
+    it("should call requested command", async () => {
+      const aboutStub = sandbox.stub().resolves();
+      const client = mock<discordjs.Client>();
+      const msg = mock<discordjs.Message>();
+      msg.content = `${testPrefix}about`;
+      msg.attachments = new discordjs.Collection();
+      msg.channel.startTyping = sandbox.stub();
+      msg.channel.stopTyping = sandbox.stub();
+      msg.guild.id = "server_id";
+
+      const clientInt = extendsClientToClientInt(client);
+      clientInt.prefix = { server_id: testPrefix };
+      clientInt.commands = { about: mockCmd("about", aboutStub) };
+      clientInt.customListeners = await getListeners();
+      Object.keys(clientInt.customListeners).forEach((key) => {
+        const stub = sandbox.stub();
+        stub.resolves();
+        clientInt.customListeners[key] = mockListener(key, stub);
+      });
+
+      const msgPromise = onMessage(msg, clientInt);
+      await sandbox.clock.tickAsync(3000);
+
+      await msgPromise;
+
+      expect(aboutStub).calledOnce;
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description:
Intent is to resolve issue with usage statistics not updating.

- corrects usage & level listener names to match that of file
- Tests listener run function called
- Tests for return early from DM
- Tests for return early from non-Discord server
- Tests for return early from DM prefix mismatch

### Validation Steps

#### Check that usage stats are updated
1. send `|optout remove`
1.1 Pre-step to ensure you are being tracked by usage and level statistics
1. send `|usage help`, note the number
1. send `|help`
1. send `|usage help`, note the number should increase

#### Check that level stats are updated
1. send `|optout remove`
1.1 Pre-step to ensure you are being tracked by usage and level statistics
1. send `|level`, note the experience points and level
1. send `|level`, note the number should increase


#### Check that usage stats are _not_ updated
1. send `|optout add`
1.1 Pre-step to ensure you are _not_ being tracked by usage and level statistics
1.2 Issuing this command will count towards level/usage unless you are already opt-out
1. send `|usage help`, note the number
1. send `|help`
1. send `|usage help`, note the number _not_ should increase

#### Check that level stats are _not_ updated
1. send `|optout add`
1.1 Pre-step to ensure you are _not_ being tracked by usage and level statistics
1.2 Issuing this command will count towards level/usage unless you are already opt-out
1. send `|level`, note the experience points and level
1. send `|level`, note the number should _not_ increase


## Related Issue:

Closes #204 
